### PR TITLE
Fixed some race condition for self.heartbeat_last_received check

### DIFF
--- a/aiormq/connection.py
+++ b/aiormq/connection.py
@@ -226,6 +226,9 @@ class Connection(Base):
         if not self.connection_tune.heartbeat:
             return
 
+        if not hasattr(self, 'heartbeat_last_received'):
+            self.heartbeat_last_received = self.loop.time()
+
         heartbeat_interval = (
             self.connection_tune.heartbeat * self.HEARTBEAT_INTERVAL_MULTIPLIER
         )


### PR DESCRIPTION
Hi!

As specified here https://github.com/mosquito/aiormq/issues/2#issuecomment-466036659 i quite often ran into some race condition when `self.heartbeat_last_received` was not defined yet due to the fact that no reads were performed.

I understand that my code is just a workaround, but probably you can find the idea useful.