### PR TITLE
Connection is now a valid hearthbeat event

### DIFF
--- a/aiormq/connection.py
+++ b/aiormq/connection.py
@@ -226,6 +226,8 @@ class Connection(Base):
         if not self.connection_tune.heartbeat:
             return
 
+        self.heartbeat_last_received = self.loop.time()
+        
         heartbeat_interval = (
             self.connection_tune.heartbeat * self.HEARTBEAT_INTERVAL_MULTIPLIER
         )


### PR DESCRIPTION
When a connection is established it will forcefully initialize self.heartbeat_last_received to mark the connection event as a synonym to hearthbeat