### PR TITLE
fix type hints

### DIFF
--- a/aiormq/connection.py
+++ b/aiormq/connection.py
@@ -66,7 +66,7 @@ class Connection(Base):
         return b64decode(data) if data else data
 
     def __init__(self, url: URLorStr, *, parent=None,
-                 loop: asyncio.get_event_loop() = None):
+                 loop: asyncio.AbstractEventLoop = None):
 
         super().__init__(
             loop=loop or asyncio.get_event_loop(),


### PR DESCRIPTION
Early initialization of the evnet loop when there is a problem with the python type hints.

for example:
* OS Version: CentOS 7 x64
* Python Version: Python 3.7.3
* CPU Count: 4

requirements.txt
```
aio-pika==5.5.2
aiormq==2.5.1
idna==2.8
multidict==4.5.2
pamqp==2.3.0
tornado==6.0.2
yarl==1.3.0
```

main.py
```python

from platform import system
from asyncio import get_event_loop

import aio_pika     # The error happenning when import aio_pika package.

from tornado.netutil import bind_sockets
from tornado.httpserver import HTTPServer
from tornado.web import Application, RequestHandler
from tornado.process import cpu_count, fork_processes


class MainHandler(RequestHandler):
    def get(self):
        self.write("Hello, world")


class Entry:

    def __init__(self):
        self._sockets = bind_sockets(8080)

        if system() == "Linux":
            fork_processes(cpu_count())

        self._loop = get_event_loop()
        self._http_server = HTTPServer(Application([
            (r"/", MainHandler),
        ]))

    def start(self):
        self._http_server.add_sockets(self._sockets)
        self._loop.run_forever()


if __name__ == "__main__":
    Entry().start()
```

output:
```
Traceback (most recent call last):
  File "/usr/local/lib/python3.7/asyncio/selector_events.py", line 251, in _add_reader
    key = self._selector.get_key(fd)
  File "/usr/local/lib/python3.7/selectors.py", line 192, in get_key
    raise KeyError("{!r} is not registered".format(fileobj)) from None
KeyError: '6 is not registered'
```