### PR TITLE
[fix] exclude tests from distribution

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ module = SourceFileLoader(
 setup(
     name='aiormq',
     version=module.__version__,
-    packages=find_packages(exclude='tests'),
+    packages=find_packages(exclude=['tests', ]),
     license=module.package_license,
     description=module.package_info,
     long_description=open("README.rst").read(),


### PR DESCRIPTION
Fixes a bug in setup.py where the distribution exports the package `tests` along with the actual library. The issue is that the `exclude` argument of find_packages is an *iterable* of excluded package names, so currently it excludes names `t`, `e`, `s`, `t`, and `s` (see setuptools source: https://github.com/pypa/setuptools/blob/8aeff6b2c9a64e47ad2a22533d7e65c08cd4103f/setuptools/__init__.py#L53).

This leads to a nasty name conflict in any project that depends on aiormq: if there is a top-level `tests` package (which is our case), tests potentially break as `from tests import helpers` finds aiormq's tests instead.