### PR TITLE
Send amqp Close frame on connection close

### DIFF
--- a/aiormq/connection.py
+++ b/aiormq/connection.py
@@ -397,10 +397,11 @@ class Connection(Base):
         async def close():
             await self.__rpc(spec.Connection.Close(), wait_response=False)
             await self._reader_task
-        await asyncio.wait_for(await close(), timeout=Connection.CLOSE_TIMEOUT)
+        await asyncio.wait_for(close(), timeout=Connection.CLOSE_TIMEOUT)
         writer = self.writer
         self.reader = None
         self.writer = None
+        self._reader_task = None
 
         # noinspection PyShadowingNames
         writer.close()

--- a/aiormq/connection.py
+++ b/aiormq/connection.py
@@ -55,6 +55,7 @@ def parse_int(v: str):
 
 
 class Connection(Base):
+    CLOSE_TIMEOUT = 1.0
     FRAME_BUFFER = 10
     # Interval between sending heartbeats based on the heartbeat(timeout)
     HEARTBEAT_INTERVAL_MULTIPLIER = 0.5
@@ -81,6 +82,7 @@ class Connection(Base):
         else:
             self.vhost = self.url.path[1:]
 
+        self._reader_task = None  # type: asyncio.Task
         self.reader = None  # type: asyncio.StreamReader
         self.writer = None  # type: asyncio.StreamWriter
         self.ssl_certs = SSLCerts(
@@ -255,7 +257,7 @@ class Connection(Base):
         await self.__rpc(spec.Connection.Open(virtual_host=self.vhost))
 
         # noinspection PyAsyncCall
-        self.create_task(self.__reader())
+        self._reader_task = self.create_task(self.__reader())
 
         # noinspection PyAsyncCall
         self.create_task(self.__heartbeat_task())
@@ -355,6 +357,8 @@ class Connection(Base):
                 self.heartbeat_last_received = self.loop.time()
 
                 if channel == 0:
+                    if isinstance(frame, spec.Connection.CloseOk):
+                        return
                     if isinstance(frame, spec.Connection.Close):
                         return await self.close(self.__exception_by_code(frame))
                     elif isinstance(frame, Heartbeat):
@@ -390,6 +394,10 @@ class Connection(Base):
             await self.close(e)
 
     async def _on_close(self, exc=exc.ConnectionClosed(0, 'normal closed')):
+        async def close():
+            await self.__rpc(spec.Connection.Close(), wait_response=False)
+            await self._reader_task
+        await asyncio.wait_for(await close(), timeout=Connection.CLOSE_TIMEOUT)
         writer = self.writer
         self.reader = None
         self.writer = None


### PR DESCRIPTION
Connection.close() does not properly close the connection. The socket is closed without sending a Close frame to the connection. Using RabbitMQ, this causes the message `client unexpectedly closed TCP connection` to be displayed. This pull request attempts to send the Close frame and then waits to receive the CloseOk frame, which indicates that the socket is safe to close. If this doesn't happened within a timeout, it closes the socket anyways. I wasn't sure what a good value for the timeout would be so I left it at one second.