### PR TITLE
fixes #55

### DIFF
--- a/aiormq/channel.py
+++ b/aiormq/channel.py
@@ -99,10 +99,12 @@ class Channel(Base):
             try:
                 result = await self.rpc_frames.get()
             except asyncio.CancelledError as e:
+                # channel already closed
                 if self.is_closed:
                     raise
 
                 try:
+                    # user cancel rpc call trying to wait result
                     result = await asyncio.wait_for(
                         self.rpc_frames.get(),
                         self.REJECT_CANCELLED_FRAME_TIMEOUT

--- a/aiormq/channel.py
+++ b/aiormq/channel.py
@@ -99,6 +99,9 @@ class Channel(Base):
             try:
                 result = await self.rpc_frames.get()
             except asyncio.CancelledError as e:
+                if self.is_closed:
+                    raise
+
                 try:
                     result = await asyncio.wait_for(
                         self.rpc_frames.get(),

--- a/aiormq/channel.py
+++ b/aiormq/channel.py
@@ -98,7 +98,7 @@ class Channel(Base):
 
             try:
                 result = await self.rpc_frames.get()
-            except asyncio.CancelledError as e:
+            except asyncio.CancelledError:
                 # channel already closed
                 if self.is_closed:
                     raise
@@ -112,7 +112,7 @@ class Channel(Base):
                     log.warning(
                         "Frame %r was rejected because task cancelled", result
                     )
-                except asyncio.TimeoutError:
+                except asyncio.TimeoutError as e:
                     await self.close(e)
 
                 raise

--- a/aiormq/connection.py
+++ b/aiormq/connection.py
@@ -16,7 +16,7 @@ from . import exceptions as exc
 from .auth import AuthMechanism
 from .base import Base, task
 from .channel import Channel
-from .tools import censor_url
+from .tools import censor_url, shield
 from .types import (
     ArgumentsType, SSLCerts,
     URLorStr
@@ -187,6 +187,7 @@ class Connection(Base):
             [m.name for m in AuthMechanism]
         )
 
+    @shield
     async def __rpc(self, request: spec.Frame, wait_response=True):
         self.writer.write(pamqp.frame.marshal(request, 0))
 


### PR DESCRIPTION
It's so brutal to protect the whole `rpc` method. I think close whole channel when RPC stuck in cancelling state is more controllable from the end-user side.