### PR TITLE
Add support for password-less certificate

### DIFF
--- a/aiormq/connection.py
+++ b/aiormq/connection.py
@@ -155,7 +155,7 @@ class Connection(Base):
             cadata=self.ssl_certs.cadata,
         )
 
-        if self.ssl_certs.key:
+        if self.ssl_certs.cert or self.ssl_certs.key:
             context.load_cert_chain(self.ssl_certs.cert, self.ssl_certs.key)
 
         if not self.ssl_certs.verify:


### PR DESCRIPTION
If the certificate requires no password, it's okay not to provide a key file.

Currently, a workaround is to provide the same file as both `certfile` and `keyfile`.