### PR TITLE
fix: wait on _reader_task before setting it to None

### DIFF
--- a/aiormq/connection.py
+++ b/aiormq/connection.py
@@ -436,13 +436,13 @@ class Connection(Base):
         writer = self.writer
         self.reader = None
         self.writer = None
+
+        await asyncio.gather(self._reader_task, return_exceptions=True)
         self._reader_task = None
 
         await asyncio.gather(
             self.__close_writer(writer), return_exceptions=True
         )
-
-        await asyncio.gather(self._reader_task, return_exceptions=True)
 
     @property
     def server_capabilities(self) -> ArgumentsType:


### PR DESCRIPTION
This commit fixes issue when asyncio.gather() is called on self._reader_task, that is being set to None.

See https://github.com/mosquito/aiormq/issues/76 for more details.