### PR TITLE
Fix SSL certificate verification

### DIFF
--- a/aiormq/connection.py
+++ b/aiormq/connection.py
@@ -145,11 +145,7 @@ class Connection(Base):
 
     def _get_ssl_context(self):
         context = ssl.create_default_context(
-            (
-                ssl.Purpose.SERVER_AUTH
-                if self.ssl_certs.key
-                else ssl.Purpose.CLIENT_AUTH
-            ),
+            ssl.Purpose.SERVER_AUTH,
             capath=self.ssl_certs.capath,
             cafile=self.ssl_certs.cafile,
             cadata=self.ssl_certs.cadata,

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -300,4 +300,3 @@ async def test_ssl_verification_fails_without_trusted_ca(event_loop):
     with pytest.raises(ConnectionError, match=".*CERTIFICATE_VERIFY_FAILED.*"):
         connection = aiormq.Connection(url, loop=event_loop)
         await connection.connect()
-

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -7,7 +7,7 @@ from binascii import hexlify
 
 import aiormq
 from aiormq.auth import AuthBase, PlainAuth
-from .conftest import skip_when_quick_test
+from .conftest import skip_when_quick_test, AMQP_URL
 
 
 pytestmark = pytest.mark.asyncio
@@ -292,3 +292,12 @@ URL_VHOSTS = [
 @pytest.mark.parametrize("url,vhost", URL_VHOSTS)
 async def test_connection_urls_vhosts(url, vhost, event_loop):
     assert aiormq.Connection(url, loop=event_loop).vhost == vhost
+
+
+async def test_ssl_verification_fails_without_trusted_ca(event_loop):
+    url = AMQP_URL.with_scheme("amqps")
+    print(url)
+    with pytest.raises(ConnectionError, match=".*CERTIFICATE_VERIFY_FAILED.*"):
+        connection = aiormq.Connection(url, loop=event_loop)
+        await connection.connect()
+

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -296,7 +296,6 @@ async def test_connection_urls_vhosts(url, vhost, event_loop):
 
 async def test_ssl_verification_fails_without_trusted_ca(event_loop):
     url = AMQP_URL.with_scheme("amqps")
-    print(url)
     with pytest.raises(ConnectionError, match=".*CERTIFICATE_VERIFY_FAILED.*"):
         connection = aiormq.Connection(url, loop=event_loop)
         await connection.connect()


### PR DESCRIPTION
The `Connection` doesn't always verify the server certificate when it should, because the `SSLContext` initialization is incorrect. It calls [ssl.create_default_context](https://docs.python.org/3/library/ssl.html#ssl.create_default_context) with `purpose` either `SERVER_AUTH` or `CLIENT_AUTH` based on whether a SSL client key is provided, but that's not how the `purpose` is intended to be used. Since `aiormq` always creates a client-side socket, the client always authenticates the server in this context - which means `SERVER_AUTH` is the only correct value.

Having said that, the issue is fixed by always initializing the default SSL context with the correct `SERVER_AUTH` purpose, which sets the `verify_mode` to `CERT_REQUIRED` - as opposed to `CLIENT_AUTH`, where `verify_mode` is set to `CERT_NONE`. The fact that `CLIENT_AUTH` was sometimes (incorrectly) used meant that server certificate was _not_ verified in certain circumstances, and there is no way of enforcing the verification - `no_verify_ssl` option can only suppress the verification, but not turn it on.

This PR fixes the issue and adds a corresponding test (which would otherwise be failing without the fix).