### PR TITLE
Pin yarl version to 1.4.2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ setup(
     url="https://github.com/mosquito/aiormq",
     author=module.__author__,
     author_email=module.team_email,
-    install_requires=["pamqp==2.3.0", "yarl"],
+    install_requires=["pamqp==2.3.0", "yarl==1.4.2"],
     keywords=["rabbitmq", "asyncio", "amqp", "amqp 0.9.1", "driver", "pamqp"],
     classifiers=[
         "Development Status :: 5 - Production/Stable",


### PR DESCRIPTION
PR for https://github.com/mosquito/aiormq/issues/88

yarl==1.5 makes this library basically unusable without installing yarl==1.4.2 manually. I would suggest to merge this temporary hotfix as soon as possible and then find the root cause of the issue.