### PR TITLE
Fix client properties processing.

### DIFF
--- a/aiormq/connection.py
+++ b/aiormq/connection.py
@@ -178,7 +178,7 @@ class Connection(Base):
         }
 
         properties.update(parse_connection_name(self.connection_name))
-        properties.update(kwargs.get("client_properties", {}))
+        properties.update(kwargs)
         return properties
 
     @staticmethod


### PR DESCRIPTION
If client properties are passed in like
```python
connect(client_properties={'connection_name': 'My PubSub!'})
```
they are ignored in the current implementation. It only works if passed in like:
```python
connect(client_properties={'client_properties': {'connection_name': 'My PubSub!'}})
```
which is probably not the originally desired format and breaks from aio-pika doc examples.

This fixes the argument processing to be like the first example. Fixes mosquito/aio-pika#301 and fixes mosquito/aio-pika#360.