### PR TITLE
Fix delivery confirmation

### DIFF
--- a/aiormq/channel.py
+++ b/aiormq/channel.py
@@ -6,7 +6,6 @@ from collections import OrderedDict
 from contextlib import suppress
 from functools import partial
 from io import BytesIO
-from types import MappingProxyType
 from typing import Any, Dict, Optional, Union
 
 import pamqp.frame
@@ -32,12 +31,6 @@ from .types import (
 
 
 log = logging.getLogger(__name__)
-
-
-
-METHOD_IDS = MappingProxyType({
-
-})
 
 
 class Channel(Base):
@@ -348,9 +341,7 @@ class Channel(Base):
                     continue
                 elif isinstance(frame, spec.Basic.CancelOk):
                     self.consumers.pop(frame.consumer_tag, None)
-                elif isinstance(
-                    frame, (spec.Basic.Ack, spec.Basic.Nack, spec.Basic.Reject),
-                ):
+                elif isinstance(frame, (spec.Basic.Ack, spec.Basic.Nack)):
                     with suppress(Exception):
                         await self._on_confirm(frame)
                     continue


### PR DESCRIPTION
I see there are three frame types (`Basic.Ack`, `Basic.Nack` and `Basic.Reject`) are handled as confirmation frames. I doubt `Basic.Reject` is confirmation type because there is only "C:REJECT" in "basic" class grammar within [reference](https://www.rabbitmq.com/amqp-0-9-1-reference.html).