### PR TITLE
Make Python version compatible with PEP 345

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ setup(
         "Programming Language :: Python :: Implementation :: PyPy",
         "Programming Language :: Python :: Implementation :: CPython",
     ],
-    python_requires=">3.6.*",
+    python_requires=">=3.6",
     package_data={"aiormq": ["py.typed"]},
     extras_require={
         "develop": [


### PR DESCRIPTION
This just changes the `python_requires` in `setup.py` to use the version definition supported by PEP 345.

See [here](https://github.com/python-poetry/poetry/issues/4095#issuecomment-851065187) for how this has become an issue.