### PR TITLE
Add support for External Auth -  Issue #113

### DIFF
--- a/aiormq/auth.py
+++ b/aiormq/auth.py
@@ -27,5 +27,11 @@ class PlainAuth(AuthBase):
         )
 
 
+class ExternalAuth(AuthBase):
+    def encode(self) -> str:
+        return ("")
+
+
 class AuthMechanism(Enum):
     PLAIN = PlainAuth
+    EXTERNAL = ExternalAuth

--- a/aiormq/connection.py
+++ b/aiormq/connection.py
@@ -299,14 +299,15 @@ class Connection(Base, AbstractConnection):
         properties.update(kwargs)
         return properties
 
-    @staticmethod
     def _credentials_class(
+        self,
         start_frame: spec.Connection.Start,
     ) -> AuthMechanism:
-        for mechanism in start_frame.mechanisms.split():
+        auth_requested = self.url.query.get('auth', 'plain').upper()
+        auth_available = start_frame.mechanisms.split()
+        if auth_requested in auth_available:
             with suppress(KeyError):
-                return AuthMechanism[mechanism]
-
+                return AuthMechanism[auth_requested]
         raise exc.AuthenticationError(
             start_frame.mechanisms, [m.name for m in AuthMechanism],
         )

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -9,7 +9,7 @@ import pytest
 from pamqp.commands import Basic
 
 import aiormq
-from aiormq.auth import AuthBase, PlainAuth
+from aiormq.auth import AuthBase, PlainAuth, ExternalAuth
 from aiormq.abc import DeliveredMessage
 
 from .conftest import AMQP_URL, cert_path, skip_when_quick_test
@@ -166,6 +166,21 @@ async def test_auth_plain(amqp_connection, loop):
     auth.value = "boo"
 
     assert auth.marshal() == "boo"
+
+async def test_auth_external(loop):
+
+    url = AMQP_URL.with_scheme("amqps")
+    url.update_query(auth='external')
+
+    connection = aiormq.Connection
+
+    auth = ExternalAuth(connection).marshal()
+
+    auth = ExternalAuth(connection)
+    auth.value = ""
+
+    assert auth.marshal() == ""
+
 
 
 async def test_channel_closed(amqp_connection):


### PR DESCRIPTION
These changes add support for external authentication.  At the protocol level, an empty bytestring is all that's required.  I changed the `Connection._credential_class` method from static to gain access to the `url` variable.  Passing `auth=external` in the connection URI enables this feature.  Addresses issue #113 