### PR TITLE
fix error on example in README file

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -99,7 +99,7 @@ Simple consumer
         on_message doesn't necessarily have to be defined as async.
         Here it is to show that it's possible.
         """
-        print(" [x] Received message %r" % message)
+        print(" [x] Received message %r" % (message,))
         print("Message body is: %r" % message.body)
         print("Before sleep!")
         await asyncio.sleep(5)   # Represents async I/O operations


### PR DESCRIPTION
Hi, thank you for this module. 
I find a small bug in the example on the README file when testing this module. In section simple consumer we get an error for this syntax:
```print(" [x] Received message %r" % message)```

It raises TypeError:

```Traceback (most recent call last):
  File "simple_consumer.py", line 10, in on_message
    print(" [x] Received message %r" % message)
TypeError: not all arguments converted during string formatting```

