### PR TITLE
Fix implementation for `Connection.is_opened`.

### DIFF
--- a/aiormq/connection.py
+++ b/aiormq/connection.py
@@ -271,7 +271,11 @@ class Connection(Base, AbstractConnection):
 
     @property
     def is_opened(self) -> bool:
-        return not self._writer_task.done() is not None and not self.is_closed
+        return (
+            hasattr(self, "_writer_task") and
+            not self._writer_task.done() and
+            not self.is_closed
+        )
 
     def __str__(self) -> str:
         return str(censor_url(self.url))

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -19,6 +19,8 @@ CERT_PATH = os.path.abspath(os.path.join(os.path.dirname(__file__), "certs"))
 
 
 async def test_simple(amqp_connection: aiormq.Connection):
+    assert amqp_connection.is_opened
+
     channel1 = await amqp_connection.channel()
     await channel1.basic_qos(prefetch_count=1)
 
@@ -69,6 +71,8 @@ async def test_simple(amqp_connection: aiormq.Connection):
 
     with pytest.raises(RuntimeError):
         await amqp_connection.channel()
+
+    assert not amqp_connection.is_opened
 
 
 async def test_channel_reuse(amqp_connection: aiormq.Connection):


### PR DESCRIPTION
The first patch fixes the implementation for `Connection.is_opened`, the second adds tests on this attribute.

This property could raise an issue when the Connection object has never been connected as `_writer_task` was never set.
The comparison was also always False because `self._writer_task.done()` always returns a boolean in the following line:

```python
    @property
    def is_opened(self) -> bool:
        return not self._writer_task.done() is not None and not self.is_closed
```