### PR TITLE
bump pamqp to 3.2.1

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ setup(
     author=module.__author__,
     author_email=module.team_email,
     install_requires=[
-        "pamqp==3.2.0",
+        "pamqp==3.2.1",
         "yarl",
     ],
     keywords=["rabbitmq", "asyncio", "amqp", "amqp 0.9.1", "driver", "pamqp"],


### PR DESCRIPTION
bump pamqp to 3.2.1 - this version now supplies a wheel, so builds a bit faster