### PR TITLE
Fix error when joining non `str` types

### DIFF
--- a/aiormq/exceptions.py
+++ b/aiormq/exceptions.py
@@ -28,7 +28,7 @@ class AMQPConnectionError(AMQPError, ConnectionError):
 
     def __repr__(self) -> str:
         if self.args:
-            return f"<{self.__class__.__name__}. {'.'.join(self.args)}>"
+            return f"<{self.__class__.__name__}: {self.args!r}>"
         return AMQPError.__repr__(self)
 
 


### PR DESCRIPTION
`AMQPConnectionError.__repr__` uses `join` on `self.args`. But `self.args` may contain types other than `str`.

Example:
```
<AMQPConnectionError: (111, 'Connection refused')>
```
Instead of `join` - refactor to use `repr` for `self.args` - as in other places.
