### PR TITLE
basic_publish: Don't create drain_future until use

### DIFF
--- a/aiormq/channel.py
+++ b/aiormq/channel.py
@@ -628,7 +628,6 @@ class Channel(Base, AbstractChannel):
         wait: bool = True,
     ) -> Optional[ConfirmationFrameType]:
         _check_routing_key(routing_key)
-        drain_future = self.create_future() if wait else None
         countdown = Countdown(timeout=timeout)
 
         publish_frame = spec.Basic.Publish(
@@ -677,6 +676,7 @@ class Channel(Base, AbstractChannel):
             body_frames = [publish_frame, content_header]
             body_frames += self._split_body(body)
 
+            drain_future = self.create_future() if wait else None
             await countdown(
                 self.write_queue.put(
                     ChannelFrame.marshall(


### PR DESCRIPTION
When the future is created before the lock is acquired, an asyncio
warning about "Future exception was never retrieved" can be logged if
connection is lost while waiting for the lock.


This situation was found in a private test suite; the fix solves the issue we were seeing and passes all existing `aiormq` tests.  If you can point me towards existing connection loss tests that I can emulate, I can try to add one that provokes the issue.  Since it's just a logged warning and not a behavioral issue, I'm not sure it's worth a whole lot of effort to add a test just for this, though.
