### PR TITLE
Ensure locks are released when leaving a Countdown context

### DIFF
--- a/aiormq/tools.py
+++ b/aiormq/tools.py
@@ -113,6 +113,4 @@ class CountdownContext(AsyncContextManager):
         self, exc_type: Optional[Type[BaseException]],
         exc_val: Optional[BaseException], exc_tb: Optional[TracebackType],
     ) -> Any:
-        return await self.countdown(
-            self.ctx.__aexit__(exc_type, exc_val, exc_tb),
-        )
+        return await self.ctx.__aexit__(exc_type, exc_val, exc_tb)


### PR DESCRIPTION
When using a Countdown as a context manager with a lock, there was a possibility of not releasing the lock when exiting the context (if unlucky with timeouts).

As an example, when processing a large batch of basic_publish calls using a short timeout, there is a certain probability that the timeout will be hit during the put operation, for instance. This means that when the time comes to run __aexit__, the Countdown logic will short-circuit, causing the lock.release() to never be called.