### PR TITLE
remove timeout management

### DIFF
--- a/aiormq/base.py
+++ b/aiormq/base.py
@@ -9,7 +9,7 @@ from .abc import (
     AbstractBase, AbstractFutureStore, CoroutineType, ExceptionType, TaskType,
     TaskWrapper, TimeoutType,
 )
-from .tools import Countdown, shield
+from .tools import legacy_timeout, shield
 
 
 T = TypeVar("T")
@@ -130,15 +130,13 @@ class Base(AbstractBase):
         with suppress(Exception):
             await self._cancel_tasks(exc)
 
+    @legacy_timeout
     async def close(
         self, exc: Optional[ExceptionType] = asyncio.CancelledError,
-        timeout: TimeoutType = None,
     ) -> None:
         if self.is_closed:
             return None
-
-        countdown = Countdown(timeout)
-        await countdown(self.__closer(exc))
+        await self.__closer(exc)
 
     def __repr__(self) -> str:
         cls_name = self.__class__.__name__

--- a/aiormq/tools.py
+++ b/aiormq/tools.py
@@ -51,68 +51,12 @@ def awaitable(
     return wrap
 
 
-class Countdown:
-    __slots__ = "loop", "deadline"
-
-    if platform.system() == "Windows":
-        @staticmethod
-        def _now() -> float:
-            # windows monotonic timer resolution is not enough.
-            # Have to use time.time()
-            return time.time()
-    else:
-        @staticmethod
-        def _now() -> float:
-            return time.monotonic()
-
-    def __init__(self, timeout: TimeoutType = None):
-        self.loop: asyncio.AbstractEventLoop = asyncio.get_event_loop()
-        self.deadline: TimeoutType = None
-
-        if timeout is not None:
-            self.deadline = self._now() + timeout
-
-    def get_timeout(self) -> TimeoutType:
-        if self.deadline is None:
-            return None
-
-        current = self._now()
-        if current >= self.deadline:
-            raise asyncio.TimeoutError
-
-        return self.deadline - current
-
-    async def __call__(self, coro: Awaitable[T]) -> T:
-        try:
-            timeout = self.get_timeout()
-        except asyncio.TimeoutError:
-            fut = asyncio.ensure_future(coro)
-            fut.cancel()
-            await asyncio.gather(fut, return_exceptions=True)
-            raise
-
-        if self.deadline is None and not timeout:
-            return await coro
-        return await asyncio.wait_for(coro, timeout=timeout)
-
-    def enter_context(
-        self, ctx: AsyncContextManager[T],
-    ) -> AsyncContextManager[T]:
-        return CountdownContext(self, ctx)
-
-
-class CountdownContext(AsyncContextManager):
-    def __init__(self, countdown: Countdown, ctx: AsyncContextManager):
-        self.countdown: Countdown = countdown
-        self.ctx: AsyncContextManager = ctx
-
-    async def __aenter__(self) -> T:
-        return await self.countdown(self.ctx.__aenter__())
-
-    async def __aexit__(
-        self, exc_type: Optional[Type[BaseException]],
-        exc_val: Optional[BaseException], exc_tb: Optional[TracebackType],
-    ) -> Any:
-        return await self.countdown(
-            self.ctx.__aexit__(exc_type, exc_val, exc_tb),
-        )
+def legacy_timeout(func):
+    @wraps(func)
+    async def wrapper(*args, timeout: TimeoutType = None, **kwargs):
+        if timeout is None:
+            return await func(*args, **kwargs)
+        else:
+            return await asyncio.wait_for(func(*args, **kwargs),
+                                          timeout=timeout)
+    return wrapper

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -2,7 +2,7 @@ import asyncio
 
 import pytest
 
-from aiormq.tools import Countdown, awaitable
+from aiormq.tools import awaitable
 
 
 def simple_func():
@@ -46,18 +46,3 @@ AWAITABLE_FUNCS = [
 @pytest.mark.parametrize("func,result", AWAITABLE_FUNCS)
 async def test_awaitable(func, result, loop):
     assert await awaitable(func)() == result
-
-
-async def test_countdown(loop):
-    countdown = Countdown(timeout=0.1)
-    await countdown(asyncio.sleep(0))
-
-    # waiting for the countdown exceeded
-    await asyncio.sleep(0.2)
-
-    task = asyncio.create_task(asyncio.sleep(0))
-
-    with pytest.raises(asyncio.TimeoutError):
-        await countdown(task)
-
-    assert task.cancelled()


### PR DESCRIPTION
timeout parameters are useless, this is all managed by asyncio directly. For legacy purposes, a @legacy_timeout decorator adds the legacy timeout parameters and hands them over to asyncio.wait_for.