### PR TITLE
hotfix: unquoting vhost in path

### DIFF
--- a/aiormq/connection.py
+++ b/aiormq/connection.py
@@ -286,7 +286,9 @@ class Connection(Base, AbstractConnection):
         if self.url.path == "/" or not self.url.path:
             self.vhost = "/"
         else:
-            self.vhost = self.url.path[1:]
+            quoted_vhost = self.url.path[1:]
+            # yarl>=1.9.5 skips unquoting backslashes in path
+            self.vhost = quoted_vhost.replace("%2F", "/")
 
         self.ssl_context = context
         self.ssl_certs = SSLCerts(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "aiormq"
-version = "6.8.0"
+version = "6.8.1"
 description = "Pure python AMQP asynchronous client library"
 authors = ["Dmitry Orlov <me@mosquito.su>"]
 readme = "README.rst"


### PR DESCRIPTION
On August 30, 2024, [yarl](https://github.com/aio-libs/yarl) released version 1.9.5. On this version, they introduced [breaking changes for parsing the `%2F` char](https://github.com/aio-libs/yarl/pull/1057) in path, which is frequently used by vhosts in the AMQP connection strings.

```py
url = yarl.URL("amqp://localhost/%2f")
print(url.path)
# Yarl v1.9.4 -> `//` -> self.vhost = '/' 
# Yarl v1.9.5 -> `/%2F` -> self.vhost = '%2F'
```

This bug broke our critical production system, which relied on `%2F` as the vhost and led into protocol issues.
I just wrote an quick hotfix for that issue that allows connect successfully to the RMQ with both yarl versions.

Fixes #203.