### PR TITLE
Add abstract `TransportFactory`

### DIFF
--- a/aiormq/__init__.py
+++ b/aiormq/__init__.py
@@ -2,7 +2,7 @@ from pamqp import commands as spec
 
 from . import abc
 from .channel import Channel
-from .connection import Connection, connect
+from .connection import Connection, connect, TransportFactory
 from .exceptions import (
     AMQPChannelError, AMQPConnectionError, AMQPError, AMQPException,
     AuthenticationError, ChannelAccessRefused, ChannelClosed,
@@ -34,6 +34,7 @@ __all__ = (
     "ConnectionChannelError",
     "ConnectionClosed",
     "ConnectionCommandInvalid",
+    "TransportFactory",
     "ConnectionFrameError",
     "ConnectionInternalError",
     "ConnectionNotAllowed",

--- a/aiormq/__init__.py
+++ b/aiormq/__init__.py
@@ -2,7 +2,7 @@ from pamqp import commands as spec
 
 from . import abc
 from .channel import Channel
-from .connection import Connection, connect, TransportFactory
+from .connection import Connection, connect, SSLContextProvider, TransportFactory
 from .exceptions import (
     AMQPChannelError, AMQPConnectionError, AMQPError, AMQPException,
     AuthenticationError, ChannelAccessRefused, ChannelClosed,
@@ -34,6 +34,7 @@ __all__ = (
     "ConnectionChannelError",
     "ConnectionClosed",
     "ConnectionCommandInvalid",
+    "SSLContextProvider",
     "TransportFactory",
     "ConnectionFrameError",
     "ConnectionInternalError",

--- a/aiormq/__init__.py
+++ b/aiormq/__init__.py
@@ -2,7 +2,9 @@ from pamqp import commands as spec
 
 from . import abc
 from .channel import Channel
-from .connection import Connection, connect, SSLContextProvider, TransportFactory
+from .connection import (
+    Connection, connect, SSLContextProvider, TransportFactory,
+)
 from .exceptions import (
     AMQPChannelError, AMQPConnectionError, AMQPError, AMQPException,
     AuthenticationError, ChannelAccessRefused, ChannelClosed,

--- a/aiormq/connection.py
+++ b/aiormq/connection.py
@@ -308,8 +308,6 @@ class TransportFactory(ABC):
     async def create(
             self,
             url: URL,
-            *,
-            ssl_context_provider: SSLContextProvider,
             **kwargs: Any
     ) -> Tuple[asyncio.StreamReader, asyncio.StreamWriter]:
         """Create a transport connection to the AMQP server."""
@@ -320,10 +318,10 @@ class TCPTransportFactory(TransportFactory):
     async def create(
             self,
             url: URL,
-            *,
-            ssl_context_provider: SSLContextProvider,
             **kwargs: Any
     ) -> Tuple[asyncio.StreamReader, asyncio.StreamWriter]:
+        # unexpected for asyncio.open_connection ignoring it
+        _ = kwargs.pop("ssl_context_provider", None)
         try:
             return await asyncio.open_connection(
                 host=url.host, port=url.port, ssl=None, **kwargs,
@@ -336,10 +334,9 @@ class TLSTransportFactory(TransportFactory):
     async def create(
             self,
             url: URL,
-            *,
-            ssl_context_provider: SSLContextProvider,
             **kwargs: Any
     ) -> Tuple[asyncio.StreamReader, asyncio.StreamWriter]:
+        ssl_context_provider = kwargs.pop("ssl_context_provider")
         ssl = await ssl_context_provider.get_context()
 
         try:

--- a/aiormq/connection.py
+++ b/aiormq/connection.py
@@ -3,6 +3,7 @@ import logging
 import platform
 import ssl
 import sys
+from abc import abstractmethod, ABC
 from base64 import b64decode
 from collections.abc import AsyncIterable
 from contextlib import suppress
@@ -246,6 +247,45 @@ class FrameGenerator(AsyncIterable):
         return frame
 
 
+class TransportFactory(ABC):
+    """
+    Abstract factory class allowing to open connections with generic
+    transports.
+    """
+
+    @staticmethod
+    @abstractmethod
+    def is_ssl_url(url: URL) -> bool:
+        pass
+
+    @abstractmethod
+    async def create(
+            self,
+            url: URL, ssl: Optional[ssl.SSLContext],
+            **kwargs: dict[str, Any]
+    ) -> tuple[asyncio.StreamReader, asyncio.StreamWriter]:
+        """Create a transport connection to the AMQP server."""
+        pass
+
+
+class _DefaultTransportFactory(TransportFactory):
+    @staticmethod
+    def is_ssl_url(url: URL) -> bool:
+        return url.scheme == "amqps"
+
+    async def create(
+            self,
+            url: URL, ssl: Optional[ssl.SSLContext],
+            **kwargs: Any
+    ) -> tuple[asyncio.StreamReader, asyncio.StreamWriter]:
+        try:
+            return await asyncio.open_connection(
+                host=url.host, port=url.port, ssl=ssl, **kwargs,
+            )
+        except OSError as e:
+            raise AMQPConnectionError(*e.args) from e
+
+
 class Connection(Base, AbstractConnection):
     FRAME_BUFFER_SIZE = 10
     # Interval between sending heartbeats based on the heartbeat(timeout)
@@ -274,6 +314,7 @@ class Connection(Base, AbstractConnection):
         *,
         loop: Optional[asyncio.AbstractEventLoop] = None,
         context: Optional[ssl.SSLContext] = None,
+        transport_factory: Optional[TransportFactory] = None,
         **create_connection_kwargs: Any,
     ):
 
@@ -315,6 +356,9 @@ class Connection(Base, AbstractConnection):
         self.last_channel_lock = asyncio.Lock()
         self.connected = asyncio.Event()
         self.connection_name = self.url.query.get("name")
+        self._transport_factory = (
+            transport_factory or _DefaultTransportFactory()
+        )
 
         self.__close_reply_code: int = REPLY_SUCCESS
         self.__close_reply_text: str = "normally closed"
@@ -445,8 +489,8 @@ class Connection(Base, AbstractConnection):
             raise RuntimeError("Connection already opened")
 
         ssl_context = self.ssl_context
-
-        if ssl_context is None and self.url.scheme == "amqps":
+        is_ssl_url = self._transport_factory.is_ssl_url(self.url)
+        if ssl_context is None and is_ssl_url:
             ssl_context = await self.loop.run_in_executor(
                 None, self._get_ssl_context,
             )
@@ -454,15 +498,15 @@ class Connection(Base, AbstractConnection):
 
         log.debug("Connecting to: %s", self)
         try:
-            reader, writer = await asyncio.open_connection(
-                self.url.host, self.url.port, ssl=ssl_context,
+            reader, writer = await self._transport_factory.create(
+                self.url, ssl=self.ssl_context,
                 **self.__create_connection_kwargs,
             )
+        except Exception as e:
+            log.error("error when creating transport: %r", e)
+            raise e
 
-            frame_receiver = FrameReceiver(reader)
-        except OSError as e:
-            raise AMQPConnectionError(*e.args) from e
-
+        frame_receiver = FrameReceiver(reader)
         frame: Optional[FrameTypes]
 
         try:

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -129,9 +129,9 @@ class _TcpTransportFactory(TransportFactory):
     async def create(
             self,
             url: URL,
-            ssl_context_provider: ssl.SSLContext,
             **kwargs: Any,
     ) -> Tuple[asyncio.StreamReader, asyncio.StreamWriter]:
+        ssl_context_provider = kwargs.pop("ssl_context_provider")
         assert isinstance(ssl_context_provider, SSLContextProvider)
 
         loop = asyncio.get_event_loop()


### PR DESCRIPTION
Hi @mosquito , this PR aims to add an (optional) abstract `TransportFactory` letting users to implement alternative transports. 

This PR is an alternative to #197 that brings less changes and is (hopefully) easier to merge.