### PR TITLE
fix: `test_ssl_context` fails on python 3.13

### DIFF
--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -413,6 +413,7 @@ async def test_ssl_context():
     )
     context.load_cert_chain(cert_path("client.pem"), cert_path("client.key"))
     context.check_hostname = False
+    context.verify_mode = ssl.CERT_NONE
     connection = aiormq.Connection(url, context=context)
     await connection.connect()
     await connection.close()


### PR DESCRIPTION
Test `test_ssl_context` fails with `aiormq.exceptions.AMQPConnectionError: [Errno 1] [SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: Missing Authority Key Identifier (_ssl.c:1028)` on Python 3.13.