### PR TITLE
Updating the log in the function '_on_reader_done'

### DIFF
--- a/aiormq/connection.py
+++ b/aiormq/connection.py
@@ -3,6 +3,7 @@ import logging
 import platform
 import ssl
 import sys
+import traceback
 from abc import abstractmethod, ABC
 from base64 import b64decode
 from collections.abc import AsyncIterable
@@ -626,7 +627,14 @@ class Connection(Base, AbstractConnection):
         log.debug("Reader exited for %r", self)
 
         if not task.cancelled() and task.exception() is not None:
-            log.debug("Cancelling cause reader exited abnormally")
+            log.critical(
+                "Cancelling cause reader exited abnormally\n%s",
+                "".join(traceback.format_exception(
+                    type(task.exception()),
+                    task.exception(),
+                    task.exception().__traceback__,
+                ))
+            )
             self.set_close_reason(
                 reply_code=500, reply_text="reader unexpected closed",
             )


### PR DESCRIPTION
If an incorrect frame is sent to the '__reader', it will cause a silent error. Only in debug mode can we see the error message. However, we only see the message and not the reason for the error.

Of course, the ideal solution would be a concise description of the error and an indication of what is wrong with the frame, but for now, a traceback is the compromise.

Example:
send frame where set properties.timestamp=999999999999999

1) Before
```
DEBUG:aiormq.connection:Reader exited for <Connection: "amqp://guest:******@localhost:5672/" at 0x101fbdbd0>
DEBUG:aiormq.connection:Cancelling cause reader exited abnormally
DEBUG:aiormq.connection:Sending <Connection.Close object at 0x102029e50> to <Connection: "amqp://guest:******@localhost:5672/" at 0x101fbdbd0>
DEBUG:aiormq.connection:Writer on connection amqp://guest:******@localhost:5672/ closed
DEBUG:aiormq.connection:Writer exited for <Connection: "amqp://guest:******@localhost:5672/" at 0x101fbdbd0>
DEBUG:aiormq.connection:Closing connection <Connection: "amqp://guest:******@localhost:5672/" at 0x101fbdbd0> cause: ValueError('year 33658 is out of range')
```

2) After
```
DEBUG:aiormq.connection:Reader exited for <Connection: "amqp://guest:******@localhost:5672/" at 0x101fbdbd0>
CRITICAL:aiormq.connection:Cancelling cause reader exited abnormally
Traceback (most recent call last):
  File "/Projects/aiormq/aiormq/connection.py", line 735, in __reader
    async for weight, channel, frame in frame_receiver:
  File "/Projects/aiormq/aiormq/connection.py", line 231, in __anext__
    return await self.get_frame()
           ^^^^^^^^^^^^^^^^^^^^^^
  File "/Projects/aiormq/aiormq/connection.py", line 228, in get_frame
    return pamqp.frame.unmarshal(fp.getvalue())
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/venv/venv3.12/lib/python3.12/site-packages/pamqp/frame.py", line 80, in unmarshal
    return byte_count, channel_id, _unmarshal_header_frame(frame_data)
                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/venv/venv3.12/lib/python3.12/site-packages/pamqp/frame.py", line 167, in _unmarshal_header_frame
    content_header.unmarshal(frame_data)
  File "/venv/venv3.12/lib/python3.12/site-packages/pamqp/header.py", line 105, in unmarshal
    self.properties.unmarshal(flags, data[12 + offset:])
  File "/venv/venv3.12/lib/python3.12/site-packages/pamqp/base.py", line 198, in unmarshal
    consumed, value = decode.by_type(data, data_type)
                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/venv/venv3.12/lib/python3.12/site-packages/pamqp/decode.py", line 30, in by_type
    return decoder(value)
           ^^^^^^^^^^^^^^
  File "/venv/venv3.12/lib/python3.12/site-packages/pamqp/decode.py", line 287, in timestamp
    return 8, datetime.datetime.fromtimestamp(ts_value,
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
ValueError: year 33658 is out of range

DEBUG:aiormq.connection:Sending <Connection.Close object at 0x102029e50> to <Connection: "amqp://guest:******@localhost:5672/" at 0x101fbdbd0>
DEBUG:aiormq.connection:Writer on connection amqp://guest:******@localhost:5672/ closed
DEBUG:aiormq.connection:Writer exited for <Connection: "amqp://guest:******@localhost:5672/" at 0x101fbdbd0>
DEBUG:aiormq.connection:Closing connection <Connection: "amqp://guest:******@localhost:5672/" at 0x101fbdbd0> cause: ValueError('year 33658 is out of range')
```
