### PR TITLE
Include license file in built distributions via project.license-files

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,6 +6,7 @@ authors = [{ name = "Dmitry Orlov", email = "me@mosquito.su" }]
 requires-python = ">=3.10,<4"
 readme = "README.rst"
 license = "Apache-2.0"
+license-files = ["COPYING"]
 keywords = [
     "rabbitmq",
     "asyncio",


### PR DESCRIPTION
# Summary
This PR updates package metadata so aio-pika distributions include an explicit license file reference.
- adds project.license-files = ["COPYING"] in `pyproject.toml`

# Why
Some compliance tooling (for example, licensee/licensed) needs license text artifacts in package metadata/distributions, not only an SPDX string/classifier.

Currently aiormq declares:
- license = "Apache-2.0"
- License :: OSI Approved :: Apache Software License

but built artifacts do not expose license-file metadata/text in a way these tools can consume consistently

This just adds it to the metadata so that tools like `licensed` can find the text.